### PR TITLE
use /bin/bash in build script

### DIFF
--- a/dist-scripts/build-emulatorjs.sh
+++ b/dist-scripts/build-emulatorjs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set +e
 
 . ../version.all


### PR DESCRIPTION
`/bin/sh` produces errors about unknown operator `[[`, use of `/bin/bash` solves that.