### PR TITLE
EXCEPTION_CATCHING_ALLOWED is a compile and link flag

### DIFF
--- a/Makefile.emscripten
+++ b/Makefile.emscripten
@@ -128,7 +128,8 @@ LDFLAGS := -L. --no-heap-copy $(LIBS) -s TOTAL_STACK=$(STACK_MEMORY) -s TOTAL_ME
            -s MODULARIZE=1 -s 'EXPORT_NAME="EJS_Runtime"'
 
 ifneq (,$(findstring same_cdi,$(TARGET)))
-   LDFLAGS += -s ASSERTIONS -s DISABLE_EXCEPTION_CATCHING=0
+   LDFLAGS += -s ASSERTIONS
+   LDFLAGS += -s EXCEPTION_CATCHING_ALLOWED="['_ZN18m68000_base_device11execute_runEv','_ZThn328_N18m68000_base_device11execute_runEv','_ZN15running_machine17start_all_devicesEv','_ZN12cli_frontend7executeEiPPc','_ZN8chd_file11open_commonEb','_ZN8chd_file13read_metadataEjjRNSt3__212basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE','_ZN8chd_file13read_metadataEjjRNSt3__26vectorIhNS0_9allocatorIhEEEE','_ZNK19netlist_mame_device19base_validity_checkER16validity_checker']"
 endif
 
 ifeq ($(HAVE_RWEBAUDIO), 1)


### PR DESCRIPTION
Added filtered exception catching for same_cdi as opposed to global.

EXCEPTION_CATCHING_ALLOWED is flag that needs to be present both at [compile and linking](https://emscripten.org/docs/tools_reference/settings_reference.html#exception-catching-allowed).