### PR TITLE
feat: expose controller port device API for EmulatorJS

### DIFF
--- a/Makefile.emulatorjs
+++ b/Makefile.emulatorjs
@@ -126,7 +126,8 @@ EXPORTED_FUNCTIONS = _main,_malloc,_free,_load_state, \
                      _system_restart,_cmd_savefiles,_get_core_options,_cmd_save_state,_supports_states,_reset_cheat,_toggleMainLoop, \
                      _save_file_path,_get_disk_count,_set_current_disk,_get_current_disk,_refresh_save_files,_toggle_fastforward,_set_ff_ratio, \
                      _toggle_slow_motion,_set_sm_ratio,_toggle_rewind,_set_rewind_granularity,_get_current_frame_count,_ejs_set_keyboard_enabled, \
-                     _set_vsync,_set_video_rotation,_get_video_dimensions,EmscriptenSendCommand,EmscriptenReceiveCommandReply,_get_memory_data
+                     _set_vsync,_set_video_rotation,_get_video_dimensions,EmscriptenSendCommand,EmscriptenReceiveCommandReply,_get_memory_data, \
+                     _ejs_set_controller_port_device,_ejs_get_controller_port_info
 
 EXPORTS := Browser,callMain,cwrap,getValue,HEAPU8,FS,PATH,ERRNO_CODES,AL,abort,ENV,stringToNewUTF8,UTF8ToString,Browser,EmscriptenSendCommand,EmscriptenReceiveCommandReply,EmulatorJSGetState,EmulatorJSGetMemoryData
 

--- a/input/drivers/emulatorjs_input.c
+++ b/input/drivers/emulatorjs_input.c
@@ -801,6 +801,44 @@ static int16_t rwebinput_input_state(
       case RETRO_DEVICE_MOUSE:
       case RARCH_DEVICE_MOUSE_SCREEN:
          return rwebinput_mouse_state(&rwebinput->mouse, id, device == RARCH_DEVICE_MOUSE_SCREEN);
+      case RETRO_DEVICE_LIGHTGUN:
+         {
+            struct video_viewport vp    = {0};
+            rwebinput_mouse_state_t
+               *mouse                   = &rwebinput->mouse;
+            int16_t res_x               = 0;
+            int16_t res_y               = 0;
+            int16_t res_screen_x        = 0;
+            int16_t res_screen_y        = 0;
+
+            if (!(video_driver_translate_coord_viewport_confined_wrap(
+                        &vp, mouse->x, mouse->y,
+                        &res_x, &res_y, &res_screen_x, &res_screen_y)))
+               return 0;
+
+            switch (id)
+            {
+               case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X:
+                  return res_x;
+               case RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y:
+                  return res_y;
+               case RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN:
+                  return input_driver_pointer_is_offscreen(res_x, res_y);
+               case RETRO_DEVICE_ID_LIGHTGUN_TRIGGER:
+                  return !!(mouse->buttons & (1 << RWEBINPUT_MOUSE_BTNL));
+               case RETRO_DEVICE_ID_LIGHTGUN_AUX_A:
+                  return !!(mouse->buttons & (1 << RWEBINPUT_MOUSE_BTNR));
+               case RETRO_DEVICE_ID_LIGHTGUN_AUX_B:
+                  return !!(mouse->buttons & (1 << RWEBINPUT_MOUSE_BTNM));
+               case RETRO_DEVICE_ID_LIGHTGUN_START:
+                  return !!(mouse->buttons & (1 << RWEBINPUT_MOUSE_BTN4));
+               case RETRO_DEVICE_ID_LIGHTGUN_SELECT:
+                  return !!(mouse->buttons & (1 << RWEBINPUT_MOUSE_BTN5));
+               default:
+                  break;
+            }
+         }
+         break;
       case RETRO_DEVICE_POINTER:
       case RARCH_DEVICE_POINTER_SCREEN:
          {
@@ -1046,6 +1084,7 @@ static uint64_t rwebinput_get_capabilities(void *data)
          | (1 << RETRO_DEVICE_ANALOG)
          | (1 << RETRO_DEVICE_KEYBOARD)
          | (1 << RETRO_DEVICE_MOUSE)
+         | (1 << RETRO_DEVICE_LIGHTGUN)
          | (1 << RETRO_DEVICE_POINTER);
 }
 

--- a/runloop.c
+++ b/runloop.c
@@ -8670,4 +8670,57 @@ float get_video_dimensions(const char *key)
       return -1.0f;
    }
 }
+
+void ejs_set_controller_port_device(unsigned port, unsigned device)
+{
+   retro_ctx_controller_info_t pad;
+   pad.port   = port;
+   pad.device = device;
+   core_set_controller_port_device(&pad);
+}
+
+char* ejs_get_controller_port_info(void)
+{
+   runloop_state_t     *runloop_st = &runloop_state;
+   rarch_system_info_t *sys_info   = &runloop_st->system;
+
+   if (!sys_info || !sys_info->ports.data || sys_info->ports.size == 0)
+      return "";
+
+   /* Calculate required buffer size */
+   size_t size = 1;
+   for (size_t i = 0; i < sys_info->ports.size; i++)
+   {
+      const struct retro_controller_info *port = &sys_info->ports.data[i];
+      for (size_t j = 0; j < port->num_types; j++)
+      {
+         if (!port->types[j].desc)
+            continue;
+         size += snprintf(NULL, 0, "%zu:%u:%s\n",
+               i, port->types[j].id, port->types[j].desc);
+      }
+   }
+
+   static char *rv = NULL;
+   free(rv);
+   rv = (char*)calloc(size, 1);
+   if (!rv)
+      return "";
+
+   for (size_t i = 0; i < sys_info->ports.size; i++)
+   {
+      const struct retro_controller_info *port = &sys_info->ports.data[i];
+      for (size_t j = 0; j < port->num_types; j++)
+      {
+         if (!port->types[j].desc)
+            continue;
+         char line[256];
+         snprintf(line, sizeof(line), "%zu:%u:%s\n",
+               i, port->types[j].id, port->types[j].desc);
+         strcat(rv, line);
+      }
+   }
+
+   return rv;
+}
 #endif


### PR DESCRIPTION
## Body

Hi, all.

Over the weekend I embedded EmulatorJS in [a project][freeplay], and realized that lightgun support was not implemented. This is one of two PRs that implements it. (You can see it working now in the linked project - I've applied these patches there already.) 

I am a software engineer, but I am not a C programmer, so please take a close look at this one. That said, the I've robustly tested the changes (meaning: I've beaten _Battleclash_ and _Metal Combat: Falcon's Revenge_ several times today, lol), and I've encountered no issues.

I hope this is helpful. I'm happy to answer any questions.


### Summary

This adds two new WASM-exported functions and lightgun input handling to enable EmulatorJS to support controller port device switching at runtime -- most notably, lightgun peripherals like the SNES Super Scope.

Currently, EmulatorJS has no way to change a port's device type (e.g. from Joypad to Super Scope). The core reports available device types via `RETRO_ENVIRONMENT_SET_CONTROLLER_INFO`, and `core_set_controller_port_device()` exists internally, but neither is exposed to JavaScript. This means lightgun games are unplayable across all systems.

### Changes

**`runloop.c`** -- Two new functions inside `#ifdef EMULATORJS`:

- `ejs_get_controller_port_info()` -- Serializes the controller info already stored in `sys_info->ports` (reported by the core via `SET_CONTROLLER_INFO`) into a parseable `port:deviceId:description\n` string. Follows the same pattern as `get_core_options()`.

- `ejs_set_controller_port_device(port, device)` -- Thin wrapper around `core_set_controller_port_device()`.

**`input/drivers/emulatorjs_input.c`** -- Added `RETRO_DEVICE_LIGHTGUN` case to `rwebinput_input_state()`:

- Mouse position mapped to `LIGHTGUN_SCREEN_X/Y` via existing viewport translation
- Mouse buttons mapped to lightgun buttons:
  - Left click: Trigger
  - Right click: AUX_A (Cursor)
  - Middle click: AUX_B (Turbo)
  - Button 4: Start (Pause)
  - Button 5: Select
- Advertised lightgun capability in `rwebinput_get_capabilities()`

**`Makefile.emulatorjs`** -- Added both new functions to `EXPORTED_FUNCTIONS`.

### Testing

Tested with snes9x core running SNES Super Scope games (Battle Clash, Metal Combat: Falcon's Revenge, Super Scope 6). Crosshair tracks mouse, fire/cursor/turbo buttons work correctly, device type persists across settings changes.

### Related issues

- EmulatorJS/EmulatorJS#677 -- "How to use Super Scope on snes9x core?"
- EmulatorJS/EmulatorJS#272 -- "SNES Light Gun / Super Scope support"
- EmulatorJS/EmulatorJS#816 -- "Mouse Controls?" (maintainer noted "we do also need to pass device ids to retroarch")
- EmulatorJS/EmulatorJS#1117 -- "Light gun support for PSX"

### Companion PR

The EmulatorJS JavaScript UI changes that consume these new exports will be submitted as a separate PR to EmulatorJS/EmulatorJS.

[freeplay]: https://github.com/chrisallenlane/freeplay