### PR TITLE
Add get_core_options_json

### DIFF
--- a/Makefile.emulatorjs
+++ b/Makefile.emulatorjs
@@ -123,7 +123,7 @@ OBJDIR := obj-emscripten
 
 EXPORTED_FUNCTIONS = _main,_malloc,_free,_load_state, \
                      _ejs_set_variable,_simulate_input,_shader_enable,_save_state_info,_set_cheat,_cmd_take_screenshot, \
-                     _system_restart,_cmd_savefiles,_get_core_options,_cmd_save_state,_supports_states,_reset_cheat,_toggleMainLoop, \
+                     _system_restart,_cmd_savefiles,_get_core_options,_get_core_options_json,_cmd_save_state,_supports_states,_reset_cheat,_toggleMainLoop, \
                      _save_file_path,_get_disk_count,_set_current_disk,_get_current_disk,_refresh_save_files,_toggle_fastforward,_set_ff_ratio, \
                      _toggle_slow_motion,_set_sm_ratio,_toggle_rewind,_set_rewind_granularity,_get_current_frame_count,_ejs_set_keyboard_enabled, \
                      _set_vsync,_set_video_rotation,_get_video_dimensions,EmscriptenSendCommand,EmscriptenReceiveCommandReply,_get_memory_data, \

--- a/runloop.c
+++ b/runloop.c
@@ -90,6 +90,11 @@
 #include <emscripten/emscripten.h>
 #endif
 
+#ifdef EMULATORJS
+#include <formats/rjson.h>
+#include <formats/rjson_helpers.h>
+#endif
+
 #ifdef HAVE_LIBNX
 #include <switch.h>
 #include "switch_performance_profiles.h"
@@ -8591,6 +8596,125 @@ char* get_core_options(void)
         }
     }
     return rv;
+}
+
+/* Serialises the core option list as JSON, retaining the data that
+ * get_core_options() discards: human readable descriptions, value
+ * labels, info text and visibility.
+ *
+ * The core option manager normalises every core option interface into
+ * the same representation, so this is populated for legacy
+ * (RETRO_ENVIRONMENT_SET_VARIABLES) cores too - there the description
+ * comes from the "Description; a|b|c" prefix and the value labels fall
+ * back to the raw values. */
+char* get_core_options_json(void)
+{
+   runloop_state_t       *runloop_st = &runloop_state;
+   core_option_manager_t *coreopts   = runloop_st->core_options;
+   rjsonwriter_t         *writer     = NULL;
+   static char           *rv         = NULL;
+   char                  *json       = NULL;
+   int                    len        = 0;
+   size_t i, j;
+
+   if (   !coreopts
+       || (coreopts->size == 0))
+      return "";
+
+   if (!(writer = rjsonwriter_open_memory()))
+      return "";
+
+   rjsonwriter_add_start_object(writer);
+   rjsonwriter_add_string(writer, "options");
+   rjsonwriter_add_colon(writer);
+   rjsonwriter_add_start_array(writer);
+
+   for (i = 0; i < coreopts->size; i++)
+   {
+      struct core_option *option = (struct core_option*)&coreopts->opts[i];
+
+      if (i > 0)
+         rjsonwriter_add_comma(writer);
+      rjsonwriter_add_start_object(writer);
+
+      rjsonwriter_add_string(writer, "key");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_string(writer, option->key);
+
+      /* Request the uncategorised strings - the frontend presents all
+       * core options in a single flat list */
+      rjsonwriter_add_comma(writer);
+      rjsonwriter_add_string(writer, "desc");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_string(writer,
+            core_option_manager_get_desc(coreopts, i, false));
+
+      rjsonwriter_add_comma(writer);
+      rjsonwriter_add_string(writer, "info");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_string(writer,
+            core_option_manager_get_info(coreopts, i, false));
+
+      rjsonwriter_add_comma(writer);
+      rjsonwriter_add_string(writer, "current");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_string(writer,
+            core_option_manager_get_val(coreopts, i));
+
+      rjsonwriter_add_comma(writer);
+      rjsonwriter_add_string(writer, "default");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_string(writer,
+            (option->default_index < option->vals->size)
+                  ? option->vals->elems[option->default_index].data
+                  : NULL);
+
+      rjsonwriter_add_comma(writer);
+      rjsonwriter_add_string(writer, "visible");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_bool(writer, option->visible);
+
+      rjsonwriter_add_comma(writer);
+      rjsonwriter_add_string(writer, "values");
+      rjsonwriter_add_colon(writer);
+      rjsonwriter_add_start_array(writer);
+      for (j = 0; j < option->vals->size; j++)
+      {
+         if (j > 0)
+            rjsonwriter_add_comma(writer);
+         rjsonwriter_add_start_object(writer);
+
+         rjsonwriter_add_string(writer, "value");
+         rjsonwriter_add_colon(writer);
+         rjsonwriter_add_string(writer, option->vals->elems[j].data);
+
+         rjsonwriter_add_comma(writer);
+         rjsonwriter_add_string(writer, "label");
+         rjsonwriter_add_colon(writer);
+         rjsonwriter_add_string(writer,
+               (j < option->val_labels->size)
+                     ? option->val_labels->elems[j].data
+                     : option->vals->elems[j].data);
+
+         rjsonwriter_add_end_object(writer);
+      }
+      rjsonwriter_add_end_array(writer);
+
+      rjsonwriter_add_end_object(writer);
+   }
+
+   rjsonwriter_add_end_array(writer);
+   rjsonwriter_add_end_object(writer);
+
+   json = rjsonwriter_get_memory_buffer(writer, &len);
+
+   /* The writer owns its buffer, so keep a copy alive for the
+    * frontend to read - freed on the next call */
+   free(rv);
+   rv = ((json) && (len > 0)) ? strdup(json) : NULL;
+   rjsonwriter_free(writer);
+
+   return (rv) ? rv : "";
 }
 
 void set_video_rotation(int rotation)

--- a/runloop.c
+++ b/runloop.c
@@ -8598,15 +8598,9 @@ char* get_core_options(void)
     return rv;
 }
 
-/* Serialises the core option list as JSON, retaining the data that
- * get_core_options() discards: human readable descriptions, value
- * labels, info text and visibility.
- *
- * The core option manager normalises every core option interface into
- * the same representation, so this is populated for legacy
- * (RETRO_ENVIRONMENT_SET_VARIABLES) cores too - there the description
- * comes from the "Description; a|b|c" prefix and the value labels fall
- * back to the raw values. */
+/* Outputs the Core Options as JSON, so that additional information
+ * from the core options can be read, like human readable
+ * labels, descriptions, and visibility. */
 char* get_core_options_json(void)
 {
    runloop_state_t       *runloop_st = &runloop_state;
@@ -8708,8 +8702,7 @@ char* get_core_options_json(void)
 
    json = rjsonwriter_get_memory_buffer(writer, &len);
 
-   /* The writer owns its buffer, so keep a copy alive for the
-    * frontend to read - freed on the next call */
+   /* The buffer is owned by the writer, so copy the buffer. */
    free(rv);
    rv = ((json) && (len > 0)) ? strdup(json) : NULL;
    rjsonwriter_free(writer);


### PR DESCRIPTION
Allows getting a bunch of data for the Core Options v2. It retrieves the data as JSON, so that it can be consumed and used on the frontend.

Used in https://github.com/EmulatorJS/EmulatorJS/pull/1242 .