### PR TITLE
Add blueMSX to the ASYNCIFY-required cores list

### DIFF
--- a/emulatorjs/build-emulatorjs.sh
+++ b/emulatorjs/build-emulatorjs.sh
@@ -69,7 +69,10 @@ needsThreads=("ppsspp" "azahar")
 largeThreads=("ppsspp" "azahar")
 noCHD=("mame2003" "mame2003_plus" "pcsx_rearmed" "genesis_plus_gx" "genesis_plus_gx_wide" "azahar")
 no7Zip=("bsnes")
-needsAsync=("mupen64plus_next" "dosbox_pure" "ppsspp" "azahar" "bsnes")
+# Cores that perform synchronous file I/O during retro_load_game()
+# (e.g. reading XML machine configs) need ASYNCIFY to avoid deadlocking
+# the Emscripten event loop.
+needsAsync=("mupen64plus_next" "dosbox_pure" "ppsspp" "azahar" "bsnes" "bluemsx")
 
 for f in $(ls -v *_emscripten.bc); do
   name=`echo "$f" | sed "s/\(_libretro_emscripten\|\).bc$//"`


### PR DESCRIPTION
blueMSX reads machine configuration XML files synchronously during retro_load_game() to initialize hardware emulation. Without ASYNCIFY=1 the core deadlocks on the Emscripten event loop and never reaches its main loop, causing a silent content load failure where only the RetroArch XMB menu appears.

## Related Issues

None directly — this is part of adding MSX/MSX2/SG-1000 support to EmulatorJS via the blueMSX libretro core.

## Related Pull Requests

- EmulatorJS/EmulatorJS#1244 — MSX system support + system_directory fix
- EmulatorJS/build#22 — Core build entry + system files packaging
- libretro/blueMSX-libretro#207 — Core source changes (Emscripten flags + C-BIOS fallback)


